### PR TITLE
Removed print statements from library calls

### DIFF
--- a/ADXL335.cpp
+++ b/ADXL335.cpp
@@ -49,13 +49,11 @@ void ADXL335::getAcceleration(float* ax, float* ay, float* az) {
     int x, y, z;
     float xvoltage, yvoltage, zvoltage;
     getXYZ(&x, &y, &z);
+    
     xvoltage = (float)x * ADC_REF / ADC_AMPLITUDE;
     yvoltage = (float)y * ADC_REF / ADC_AMPLITUDE;
     zvoltage = (float)z * ADC_REF / ADC_AMPLITUDE;
-    Serial.println("voltage:");
-    Serial.println(xvoltage);
-    Serial.println(yvoltage);
-    Serial.println(zvoltage);
+    
     *ax = (xvoltage - ZERO_X) / SENSITIVITY;
     *ay = (yvoltage - ZERO_Y) / SENSITIVITY;
     *az = (zvoltage - ZERO_Z) / SENSITIVITY;


### PR DESCRIPTION
As this project is intended to be used as a library, in my opinion no printing should happen inside the methods called from outside.

While it might be helpful for debugging the library it doesn't seem to be required for the average user and he*she can request the voltage values separately. 

Thanks for considering!